### PR TITLE
Add .NET 8 console implementation for Pinduoduo messaging

### DIFF
--- a/dotnet/CustomerAgent.ConsoleApp/Configuration/AppSettings.cs
+++ b/dotnet/CustomerAgent.ConsoleApp/Configuration/AppSettings.cs
@@ -1,0 +1,18 @@
+namespace CustomerAgent.ConsoleApp.Configuration;
+
+public class AppSettings
+{
+    public PddSettings Pdd { get; set; } = new();
+}
+
+public class PddSettings
+{
+    public BusinessHoursSettings BusinessHours { get; set; } = new();
+    public Dictionary<string, string> DefaultHeaders { get; set; } = new(StringComparer.OrdinalIgnoreCase);
+}
+
+public class BusinessHoursSettings
+{
+    public string Start { get; set; } = "09:00";
+    public string End { get; set; } = "23:00";
+}

--- a/dotnet/CustomerAgent.ConsoleApp/Configuration/ConfigurationLoader.cs
+++ b/dotnet/CustomerAgent.ConsoleApp/Configuration/ConfigurationLoader.cs
@@ -1,0 +1,27 @@
+using System.Text.Json;
+
+namespace CustomerAgent.ConsoleApp.Configuration;
+
+public static class ConfigurationLoader
+{
+    public static AppSettings Load(string filePath)
+    {
+        if (!File.Exists(filePath))
+        {
+            throw new FileNotFoundException($"配置文件不存在: {filePath}");
+        }
+
+        var json = File.ReadAllText(filePath);
+        var options = new JsonSerializerOptions
+        {
+            PropertyNameCaseInsensitive = true
+        };
+        var settings = JsonSerializer.Deserialize<AppSettings>(json, options);
+        if (settings is null)
+        {
+            throw new InvalidOperationException("无法解析配置文件");
+        }
+
+        return settings;
+    }
+}

--- a/dotnet/CustomerAgent.ConsoleApp/CustomerAgent.ConsoleApp.csproj
+++ b/dotnet/CustomerAgent.ConsoleApp/CustomerAgent.ConsoleApp.csproj
@@ -1,0 +1,8 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net8.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+</Project>

--- a/dotnet/CustomerAgent.ConsoleApp/Domain/Entities/Account.cs
+++ b/dotnet/CustomerAgent.ConsoleApp/Domain/Entities/Account.cs
@@ -1,0 +1,19 @@
+namespace CustomerAgent.ConsoleApp.Domain.Entities;
+
+public class Account
+{
+    public Guid Id { get; init; } = Guid.NewGuid();
+    public string Channel { get; init; } = "pinduoduo";
+    public string Username { get; set; } = string.Empty;
+    public string Password { get; set; } = string.Empty;
+    public string? UserId { get; set; }
+    public string? ShopId { get; set; }
+    public string? ShopName { get; set; }
+    public string? MallLogo { get; set; }
+    public Dictionary<string, string> Cookies { get; private set; } = new();
+
+    public void UpdateCookies(Dictionary<string, string> cookies)
+    {
+        Cookies = new Dictionary<string, string>(cookies, StringComparer.OrdinalIgnoreCase);
+    }
+}

--- a/dotnet/CustomerAgent.ConsoleApp/Domain/Entities/Shop.cs
+++ b/dotnet/CustomerAgent.ConsoleApp/Domain/Entities/Shop.cs
@@ -1,0 +1,8 @@
+namespace CustomerAgent.ConsoleApp.Domain.Entities;
+
+public class Shop
+{
+    public string ShopId { get; init; } = string.Empty;
+    public string Name { get; set; } = string.Empty;
+    public string? Logo { get; set; }
+}

--- a/dotnet/CustomerAgent.ConsoleApp/Domain/Messaging/ContextType.cs
+++ b/dotnet/CustomerAgent.ConsoleApp/Domain/Messaging/ContextType.cs
@@ -1,0 +1,18 @@
+namespace CustomerAgent.ConsoleApp.Domain.Messaging;
+
+public enum ContextType
+{
+    Text,
+    Image,
+    Video,
+    Emotion,
+    Withdraw,
+    GoodsInquiry,
+    GoodsSpec,
+    OrderInfo,
+    MallSystemMessage,
+    Auth,
+    Transfer,
+    SystemStatus,
+    MallCs
+}

--- a/dotnet/CustomerAgent.ConsoleApp/Domain/Messaging/PddUserMessage.cs
+++ b/dotnet/CustomerAgent.ConsoleApp/Domain/Messaging/PddUserMessage.cs
@@ -1,0 +1,13 @@
+using System.Text.Json;
+
+namespace CustomerAgent.ConsoleApp.Domain.Messaging;
+
+public sealed record PddUserMessage(
+    string ShopId,
+    string UserUid,
+    string? Nickname,
+    ContextType ContextType,
+    string? Text,
+    JsonElement RawMessage,
+    long? Timestamp
+);

--- a/dotnet/CustomerAgent.ConsoleApp/Infrastructure/Http/CookieUtility.cs
+++ b/dotnet/CustomerAgent.ConsoleApp/Infrastructure/Http/CookieUtility.cs
@@ -1,0 +1,49 @@
+using System.Linq;
+using System.Text.Json;
+
+namespace CustomerAgent.ConsoleApp.Infrastructure.Http;
+
+public static class CookieUtility
+{
+    public static Dictionary<string, string> Parse(string input)
+    {
+        if (string.IsNullOrWhiteSpace(input))
+        {
+            return new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+        }
+
+        input = input.Trim();
+        if (input.StartsWith("{") && input.EndsWith("}"))
+        {
+            try
+            {
+                var document = JsonDocument.Parse(input);
+                return document.RootElement
+                    .EnumerateObject()
+                    .ToDictionary(p => p.Name, p => p.Value.GetString() ?? string.Empty, StringComparer.OrdinalIgnoreCase);
+            }
+            catch (JsonException)
+            {
+                // fall back to semi-colon parsing
+            }
+        }
+
+        var result = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+        var segments = input.Split(';', StringSplitOptions.RemoveEmptyEntries);
+        foreach (var segment in segments)
+        {
+            var parts = segment.Split('=', 2);
+            if (parts.Length == 2)
+            {
+                result[parts[0].Trim()] = parts[1].Trim();
+            }
+        }
+
+        return result;
+    }
+
+    public static string BuildCookieHeader(IReadOnlyDictionary<string, string> cookies)
+    {
+        return string.Join("; ", cookies.Select(kvp => $"{kvp.Key}={kvp.Value}"));
+    }
+}

--- a/dotnet/CustomerAgent.ConsoleApp/Infrastructure/Http/PddRequestClient.cs
+++ b/dotnet/CustomerAgent.ConsoleApp/Infrastructure/Http/PddRequestClient.cs
@@ -1,0 +1,99 @@
+using System.Text;
+using System.Text.Json;
+using CustomerAgent.ConsoleApp.Configuration;
+
+namespace CustomerAgent.ConsoleApp.Infrastructure.Http;
+
+public class PddRequestClient : IDisposable
+{
+    private readonly HttpClient _httpClient;
+    private readonly Dictionary<string, string> _defaultHeaders;
+    private IReadOnlyDictionary<string, string> _cookies;
+
+    public PddRequestClient(AppSettings settings)
+    {
+        _httpClient = new HttpClient
+        {
+            Timeout = TimeSpan.FromSeconds(30)
+        };
+        _defaultHeaders = new Dictionary<string, string>(settings.Pdd.DefaultHeaders, StringComparer.OrdinalIgnoreCase);
+        _cookies = new Dictionary<string, string>();
+    }
+
+    public void UpdateCookies(IReadOnlyDictionary<string, string> cookies)
+    {
+        _cookies = new Dictionary<string, string>(cookies, StringComparer.OrdinalIgnoreCase);
+    }
+
+    public async Task<JsonDocument?> PostJsonAsync(string url, object? payload, CancellationToken cancellationToken)
+    {
+        var content = payload is null
+            ? new StringContent("{}", Encoding.UTF8, "application/json")
+            : new StringContent(JsonSerializer.Serialize(payload), Encoding.UTF8, "application/json");
+
+        return await SendAsync(url, content, cancellationToken);
+    }
+
+    public async Task<JsonDocument?> PostRawAsync(string url, string body, CancellationToken cancellationToken)
+    {
+        var content = new StringContent(body, Encoding.UTF8, "application/json");
+        return await SendAsync(url, content, cancellationToken);
+    }
+
+    private async Task<JsonDocument?> SendAsync(string url, HttpContent content, CancellationToken cancellationToken)
+    {
+        using var request = new HttpRequestMessage(HttpMethod.Post, url)
+        {
+            Content = content
+        };
+
+        foreach (var header in _defaultHeaders)
+        {
+            if (!request.Headers.TryAddWithoutValidation(header.Key, header.Value))
+            {
+                request.Content?.Headers.TryAddWithoutValidation(header.Key, header.Value);
+            }
+        }
+
+        if (_cookies.Count > 0)
+        {
+            request.Headers.Remove("Cookie");
+            request.Headers.TryAddWithoutValidation("Cookie", CookieUtility.BuildCookieHeader(_cookies));
+        }
+
+        const int maxRetries = 3;
+        var delay = TimeSpan.FromSeconds(1);
+        for (var attempt = 1; attempt <= maxRetries; attempt++)
+        {
+            try
+            {
+                using var response = await _httpClient.SendAsync(request, cancellationToken);
+                var contentString = await response.Content.ReadAsStringAsync(cancellationToken);
+
+                if (!response.IsSuccessStatusCode)
+                {
+                    throw new HttpRequestException($"请求失败: {(int)response.StatusCode} {response.ReasonPhrase}\n{contentString}");
+                }
+
+                if (string.IsNullOrWhiteSpace(contentString))
+                {
+                    return null;
+                }
+
+                return JsonDocument.Parse(contentString);
+            }
+            catch (Exception) when (attempt < maxRetries)
+            {
+                await Task.Delay(delay, cancellationToken);
+                delay = TimeSpan.FromMilliseconds(delay.TotalMilliseconds * 2 + Random.Shared.Next(100, 400));
+            }
+        }
+
+        return null;
+    }
+
+    public void Dispose()
+    {
+        _httpClient.Dispose();
+    }
+}

--- a/dotnet/CustomerAgent.ConsoleApp/Infrastructure/Persistence/InMemoryDatabase.cs
+++ b/dotnet/CustomerAgent.ConsoleApp/Infrastructure/Persistence/InMemoryDatabase.cs
@@ -1,0 +1,34 @@
+using System.Linq;
+using CustomerAgent.ConsoleApp.Domain.Entities;
+
+namespace CustomerAgent.ConsoleApp.Infrastructure.Persistence;
+
+public class InMemoryDatabase
+{
+    private readonly Dictionary<Guid, Account> _accounts = new();
+    private readonly Dictionary<string, Shop> _shops = new(StringComparer.OrdinalIgnoreCase);
+
+    public Account UpsertAccount(Account account)
+    {
+        _accounts[account.Id] = account;
+        return account;
+    }
+
+    public IReadOnlyCollection<Account> GetAccounts() => _accounts.Values.ToList();
+
+    public Account? FindAccountByUserId(string userId)
+    {
+        return _accounts.Values.FirstOrDefault(a => string.Equals(a.UserId, userId, StringComparison.OrdinalIgnoreCase));
+    }
+
+    public void SaveShop(Shop shop)
+    {
+        _shops[shop.ShopId] = shop;
+    }
+
+    public Shop? GetShop(string shopId)
+    {
+        _shops.TryGetValue(shopId, out var shop);
+        return shop;
+    }
+}

--- a/dotnet/CustomerAgent.ConsoleApp/Infrastructure/WebSockets/PddWebSocketClient.cs
+++ b/dotnet/CustomerAgent.ConsoleApp/Infrastructure/WebSockets/PddWebSocketClient.cs
@@ -1,0 +1,74 @@
+using System.Net.WebSockets;
+using System.Text;
+using System.Threading.Channels;
+using CustomerAgent.ConsoleApp.Domain.Entities;
+using CustomerAgent.ConsoleApp.Domain.Messaging;
+using CustomerAgent.ConsoleApp.Services;
+
+namespace CustomerAgent.ConsoleApp.Infrastructure.WebSockets;
+
+public class PddWebSocketClient
+{
+    private const string BaseUrl = "wss://m-ws.pinduoduo.com/";
+    private readonly Channel<PddUserMessage> _messageChannel;
+
+    public PddWebSocketClient(Channel<PddUserMessage> messageChannel)
+    {
+        _messageChannel = messageChannel;
+    }
+
+    public async Task RunAsync(Account account, string accessToken, CancellationToken cancellationToken)
+    {
+        var parameters = new Dictionary<string, string>
+        {
+            ["access_token"] = accessToken,
+            ["role"] = "mall_cs",
+            ["client"] = "web",
+            ["version"] = "202506091557"
+        };
+
+        var query = string.Join("&", parameters.Select(kvp => $"{kvp.Key}={Uri.EscapeDataString(kvp.Value)}"));
+        var uri = new Uri($"{BaseUrl}?{query}");
+
+        using var webSocket = new ClientWebSocket();
+        webSocket.Options.KeepAliveInterval = TimeSpan.FromSeconds(20);
+
+        await webSocket.ConnectAsync(uri, cancellationToken);
+
+        var buffer = new byte[32 * 1024];
+        var builder = new StringBuilder();
+
+        while (!cancellationToken.IsCancellationRequested && webSocket.State == WebSocketState.Open)
+        {
+            builder.Clear();
+            WebSocketReceiveResult? result;
+            do
+            {
+                result = await webSocket.ReceiveAsync(buffer, cancellationToken);
+                if (result.MessageType == WebSocketMessageType.Close)
+                {
+                    await webSocket.CloseAsync(WebSocketCloseStatus.NormalClosure, "closing", cancellationToken);
+                    return;
+                }
+
+                var chunk = Encoding.UTF8.GetString(buffer, 0, result.Count);
+                builder.Append(chunk);
+            } while (!result.EndOfMessage);
+
+            var payload = builder.ToString();
+            if (!PddMessageParser.TryParse(account.ShopId ?? string.Empty, payload, out var message, out var warning))
+            {
+                if (warning is not null)
+                {
+                    Console.WriteLine($"[WS] {warning}");
+                }
+                continue;
+            }
+
+            if (message is not null)
+            {
+                await _messageChannel.Writer.WriteAsync(message, cancellationToken);
+            }
+        }
+    }
+}

--- a/dotnet/CustomerAgent.ConsoleApp/Program.cs
+++ b/dotnet/CustomerAgent.ConsoleApp/Program.cs
@@ -1,0 +1,131 @@
+using System.Linq;
+using System.Threading.Channels;
+using CustomerAgent.ConsoleApp.Configuration;
+using CustomerAgent.ConsoleApp.Domain.Entities;
+using CustomerAgent.ConsoleApp.Domain.Messaging;
+using CustomerAgent.ConsoleApp.Infrastructure.Http;
+using CustomerAgent.ConsoleApp.Infrastructure.Persistence;
+using CustomerAgent.ConsoleApp.Infrastructure.WebSockets;
+using CustomerAgent.ConsoleApp.Services;
+
+var configPath = Path.Combine(AppContext.BaseDirectory, "appsettings.json");
+AppSettings settings;
+try
+{
+    settings = ConfigurationLoader.Load(configPath);
+}
+catch (Exception ex)
+{
+    Console.WriteLine($"加载配置失败: {ex.Message}");
+    return;
+}
+
+Console.WriteLine("=== 拼多多客服控制台 ===");
+Console.WriteLine("请输入账号信息，按回车确认");
+
+Console.Write("账号: ");
+var username = Console.ReadLine() ?? string.Empty;
+Console.Write("密码: ");
+var password = ReadPassword();
+Console.WriteLine();
+Console.WriteLine("请输入Cookie(支持JSON或key=value;形式):");
+var cookieInput = Console.ReadLine() ?? string.Empty;
+
+var cookies = CookieUtility.Parse(cookieInput);
+if (cookies.Count == 0)
+{
+    Console.WriteLine("未解析到有效Cookie，程序结束");
+    return;
+}
+
+var database = new InMemoryDatabase();
+var account = new Account
+{
+    Username = username,
+    Password = password
+};
+account.UpdateCookies(cookies);
+database.UpsertAccount(account);
+
+var accountService = new PddAccountService(settings);
+
+using var cts = new CancellationTokenSource();
+Console.CancelKeyPress += (_, e) =>
+{
+    e.Cancel = true;
+    cts.Cancel();
+};
+
+try
+{
+    Console.WriteLine("正在获取用户信息...");
+    var (userId, accountName, mallId) = await accountService.GetUserInfoAsync(account, cts.Token);
+    account.UserId = userId;
+    account.Username = accountName;
+    account.ShopId = mallId;
+    Console.WriteLine($"用户ID: {userId}, 昵称: {accountName}, 关联店铺ID: {mallId}");
+
+    Console.WriteLine("正在获取店铺信息...");
+    var (shopId, shopName, mallLogo) = await accountService.GetShopInfoAsync(account, cts.Token);
+    account.ShopId = shopId;
+    account.ShopName = shopName;
+    account.MallLogo = mallLogo;
+    database.SaveShop(new Shop { ShopId = shopId, Name = shopName, Logo = mallLogo });
+    Console.WriteLine($"店铺: {shopName} ({shopId})");
+
+    Console.WriteLine("正在获取token...");
+    var token = await accountService.GetTokenAsync(account, cts.Token);
+    Console.WriteLine("Token获取成功，准备连接WebSocket...");
+
+    var channel = Channel.CreateUnbounded<PddUserMessage>(new UnboundedChannelOptions
+    {
+        SingleReader = true,
+        SingleWriter = false
+    });
+
+    var messageSender = new PddMessageSender(settings);
+    var dispatcher = new PddMessageDispatcher(channel, messageSender, account);
+    var websocketClient = new PddWebSocketClient(channel);
+
+    var dispatcherTask = Task.Run(() => dispatcher.RunAsync(cts.Token), cts.Token);
+    var websocketTask = Task.Run(() => websocketClient.RunAsync(account, token, cts.Token), cts.Token);
+
+    Console.WriteLine("连接已建立，等待用户消息，按Ctrl+C退出");
+
+    await Task.WhenAll(dispatcherTask, websocketTask);
+}
+catch (OperationCanceledException)
+{
+    Console.WriteLine("用户取消，正在退出...");
+}
+catch (Exception ex)
+{
+    Console.WriteLine($"发生错误: {ex.Message}");
+}
+
+static string ReadPassword()
+{
+    var password = new Stack<char>();
+    ConsoleKeyInfo keyInfo;
+    while (true)
+    {
+        keyInfo = Console.ReadKey(intercept: true);
+        if (keyInfo.Key == ConsoleKey.Enter)
+        {
+            break;
+        }
+        if (keyInfo.Key == ConsoleKey.Backspace)
+        {
+            if (password.Count > 0)
+            {
+                password.Pop();
+                Console.Write("\b \b");
+            }
+            continue;
+        }
+        password.Push(keyInfo.KeyChar);
+        Console.Write('*');
+    }
+
+    return new string(password.Reverse().ToArray());
+}

--- a/dotnet/CustomerAgent.ConsoleApp/Services/PddAccountService.cs
+++ b/dotnet/CustomerAgent.ConsoleApp/Services/PddAccountService.cs
@@ -1,0 +1,79 @@
+using System.Text.Json;
+using CustomerAgent.ConsoleApp.Configuration;
+using CustomerAgent.ConsoleApp.Domain.Entities;
+using CustomerAgent.ConsoleApp.Infrastructure.Http;
+
+namespace CustomerAgent.ConsoleApp.Services;
+
+public class PddAccountService
+{
+    private readonly AppSettings _settings;
+
+    public PddAccountService(AppSettings settings)
+    {
+        _settings = settings;
+    }
+
+    public async Task<(string userId, string username, string mallId)> GetUserInfoAsync(Account account, CancellationToken cancellationToken)
+    {
+        using var client = new PddRequestClient(_settings);
+        client.UpdateCookies(account.Cookies);
+        using var document = await client.PostRawAsync("https://mms.pinduoduo.com/janus/api/new/userinfo", string.Empty, cancellationToken)
+            ?? throw new InvalidOperationException("获取用户信息失败: 空响应");
+
+        var root = document.RootElement;
+        if (!root.TryGetProperty("success", out var successElement) || successElement.ValueKind != JsonValueKind.True)
+        {
+            var errorMsg = root.TryGetProperty("errorMsg", out var error) ? error.GetString() : "未知错误";
+            throw new InvalidOperationException($"获取用户信息失败: {errorMsg}");
+        }
+
+        var result = root.GetProperty("result");
+        var userId = result.GetProperty("id").GetString() ?? throw new InvalidOperationException("响应缺少id");
+        var username = result.GetProperty("username").GetString() ?? string.Empty;
+        var mallId = result.GetProperty("mall_id").GetString() ?? string.Empty;
+        return (userId, username, mallId);
+    }
+
+    public async Task<(string shopId, string shopName, string? mallLogo)> GetShopInfoAsync(Account account, CancellationToken cancellationToken)
+    {
+        using var client = new PddRequestClient(_settings);
+        client.UpdateCookies(account.Cookies);
+        using var document = await client.PostJsonAsync("https://mms.pinduoduo.com/earth/api/merchant/queryMerchantInfoByMallId", new { }, cancellationToken)
+            ?? throw new InvalidOperationException("获取店铺信息失败: 空响应");
+
+        var root = document.RootElement;
+        if (!root.TryGetProperty("success", out var successElement) || successElement.ValueKind != JsonValueKind.True)
+        {
+            var errorMsg = root.TryGetProperty("errorMsg", out var error) ? error.GetString() : "未知错误";
+            throw new InvalidOperationException($"获取店铺信息失败: {errorMsg}");
+        }
+
+        var result = root.GetProperty("result");
+        var shopId = result.GetProperty("mallId").GetString() ?? throw new InvalidOperationException("响应缺少mallId");
+        var shopName = result.GetProperty("mallName").GetString() ?? string.Empty;
+        var mallLogo = result.TryGetProperty("mallLogo", out var logoElement) ? logoElement.GetString() : null;
+        return (shopId, shopName, mallLogo);
+    }
+
+    public async Task<string> GetTokenAsync(Account account, CancellationToken cancellationToken)
+    {
+        using var client = new PddRequestClient(_settings);
+        client.UpdateCookies(account.Cookies);
+        using var document = await client.PostJsonAsync("https://mms.pinduoduo.com/chats/getToken", new { version = "3" }, cancellationToken)
+            ?? throw new InvalidOperationException("获取token失败: 空响应");
+
+        var root = document.RootElement;
+        if (root.TryGetProperty("token", out var tokenElement) && tokenElement.ValueKind == JsonValueKind.String)
+        {
+            return tokenElement.GetString()!;
+        }
+
+        if (root.TryGetProperty("result", out var resultElement) && resultElement.TryGetProperty("token", out var tokenValue))
+        {
+            return tokenValue.GetString() ?? throw new InvalidOperationException("响应中token为空");
+        }
+
+        throw new InvalidOperationException("响应中未包含token字段");
+    }
+}

--- a/dotnet/CustomerAgent.ConsoleApp/Services/PddMessageDispatcher.cs
+++ b/dotnet/CustomerAgent.ConsoleApp/Services/PddMessageDispatcher.cs
@@ -1,0 +1,84 @@
+using System.Threading.Channels;
+using CustomerAgent.ConsoleApp.Domain.Entities;
+using CustomerAgent.ConsoleApp.Domain.Messaging;
+
+namespace CustomerAgent.ConsoleApp.Services;
+
+public class PddMessageDispatcher
+{
+    private readonly Channel<PddUserMessage> _channel;
+    private readonly PddMessageSender _sender;
+    private readonly Account _account;
+
+    public PddMessageDispatcher(Channel<PddUserMessage> channel, PddMessageSender sender, Account account)
+    {
+        _channel = channel;
+        _sender = sender;
+        _account = account;
+    }
+
+    public async Task RunAsync(CancellationToken cancellationToken)
+    {
+        await foreach (var message in _channel.Reader.ReadAllAsync(cancellationToken))
+        {
+            if (message.ContextType == ContextType.SystemStatus || message.ContextType == ContextType.MallSystemMessage)
+            {
+                Console.WriteLine($"[系统消息] {message.Text}");
+                continue;
+            }
+
+            Console.WriteLine("----------------------------------------");
+            Console.WriteLine($"时间: {FormatTimestamp(message.Timestamp)}");
+            Console.WriteLine($"用户: {message.Nickname ?? message.UserUid}");
+            Console.WriteLine($"类型: {message.ContextType}");
+            Console.WriteLine($"内容: {message.Text}");
+
+            if (message.ContextType != ContextType.Text && message.ContextType != ContextType.GoodsInquiry && message.ContextType != ContextType.OrderInfo)
+            {
+                Console.WriteLine("该消息类型不支持直接回复，按回车继续...");
+                Console.ReadLine();
+                continue;
+            }
+
+            Console.WriteLine("请输入回复内容(留空跳过，输入 /exit 退出):");
+            var reply = Console.ReadLine();
+            if (reply is null)
+            {
+                continue;
+            }
+
+            reply = reply.Trim();
+            if (reply.Equals("/exit", StringComparison.OrdinalIgnoreCase))
+            {
+                throw new OperationCanceledException("用户退出");
+            }
+
+            if (string.IsNullOrEmpty(reply))
+            {
+                Console.WriteLine("已跳过该消息");
+                continue;
+            }
+
+            try
+            {
+                await _sender.SendTextAsync(_account, message.UserUid, reply, cancellationToken);
+                Console.WriteLine("消息发送成功");
+            }
+            catch (Exception ex)
+            {
+                Console.WriteLine($"发送失败: {ex.Message}");
+            }
+        }
+    }
+
+    private static string FormatTimestamp(long? timestamp)
+    {
+        if (timestamp is null)
+        {
+            return DateTimeOffset.Now.ToString("yyyy-MM-dd HH:mm:ss");
+        }
+
+        var dt = DateTimeOffset.FromUnixTimeMilliseconds(timestamp.Value);
+        return dt.LocalDateTime.ToString("yyyy-MM-dd HH:mm:ss");
+    }
+}

--- a/dotnet/CustomerAgent.ConsoleApp/Services/PddMessageParser.cs
+++ b/dotnet/CustomerAgent.ConsoleApp/Services/PddMessageParser.cs
@@ -1,0 +1,152 @@
+using System.Text.Json;
+using CustomerAgent.ConsoleApp.Domain.Messaging;
+
+namespace CustomerAgent.ConsoleApp.Services;
+
+public static class PddMessageParser
+{
+    public static bool TryParse(string shopId, string payload, out PddUserMessage? message, out string? warning)
+    {
+        message = null;
+        warning = null;
+        JsonDocument document;
+        try
+        {
+            document = JsonDocument.Parse(payload);
+        }
+        catch (JsonException ex)
+        {
+            warning = $"无法解析WebSocket消息: {ex.Message}";
+            return false;
+        }
+
+        using (document)
+        {
+            var root = document.RootElement;
+            var responseType = root.TryGetProperty("response", out var responseElement)
+                ? responseElement.GetString()
+                : null;
+
+            if (responseType is null)
+            {
+                warning = "消息缺少response字段";
+                return false;
+            }
+
+            if (responseType.Equals("auth", StringComparison.OrdinalIgnoreCase))
+            {
+                var context = new PddUserMessage(
+                    shopId,
+                    root.TryGetProperty("uid", out var uidEl) ? uidEl.GetString() ?? string.Empty : string.Empty,
+                    null,
+                    ContextType.Auth,
+                    root.TryGetProperty("status", out var statusEl) ? statusEl.GetString() : null,
+                    root.Clone(),
+                    null);
+                message = context;
+                return true;
+            }
+
+            if (responseType.Equals("mall_system_msg", StringComparison.OrdinalIgnoreCase))
+            {
+                var data = root.TryGetProperty("message", out var msgEl) && msgEl.TryGetProperty("data", out var dataEl)
+                    ? dataEl.ToString()
+                    : null;
+                message = new PddUserMessage(shopId, string.Empty, null, ContextType.MallSystemMessage, data, root.Clone(), null);
+                return true;
+            }
+
+            if (!responseType.Equals("push", StringComparison.OrdinalIgnoreCase))
+            {
+                warning = $"忽略未知response类型: {responseType}";
+                return false;
+            }
+
+            if (!root.TryGetProperty("message", out var messageElement))
+            {
+                warning = "push消息缺少message字段";
+                return false;
+            }
+
+            var fromRole = messageElement.TryGetProperty("from", out var fromElement) && fromElement.TryGetProperty("role", out var roleEl)
+                ? roleEl.GetString()
+                : null;
+
+            if (string.Equals(fromRole, "mall_cs", StringComparison.OrdinalIgnoreCase))
+            {
+                warning = "忽略客服自己的消息";
+                return false;
+            }
+
+            var fromUid = messageElement.TryGetProperty("from", out var fromObj) && fromObj.TryGetProperty("uid", out var uidElement)
+                ? uidElement.GetString() ?? string.Empty
+                : string.Empty;
+            var nickname = messageElement.TryGetProperty("nickname", out var nicknameEl) ? nicknameEl.GetString() : null;
+            var timestamp = messageElement.TryGetProperty("time", out var timeEl) && timeEl.ValueKind == JsonValueKind.Number
+                ? timeEl.GetInt64()
+                : (long?)null;
+
+            ContextType contextType;
+            string? text = null;
+
+            var type = messageElement.TryGetProperty("type", out var typeElement) && typeElement.ValueKind == JsonValueKind.Number
+                ? typeElement.GetInt32()
+                : -1;
+
+            switch (type)
+            {
+                case 0:
+                    var subType = messageElement.TryGetProperty("sub_type", out var subTypeEl) && subTypeEl.ValueKind == JsonValueKind.Number
+                        ? subTypeEl.GetInt32()
+                        : -1;
+                    if (subType == 1)
+                    {
+                        contextType = ContextType.OrderInfo;
+                        text = messageElement.TryGetProperty("info", out var infoEl) ? infoEl.ToString() : null;
+                    }
+                    else if (subType == 0)
+                    {
+                        contextType = ContextType.GoodsInquiry;
+                        text = messageElement.TryGetProperty("info", out var infoEl) ? infoEl.ToString() : null;
+                    }
+                    else
+                    {
+                        contextType = ContextType.Text;
+                        text = messageElement.TryGetProperty("content", out var contentEl) ? contentEl.GetString() : null;
+                    }
+                    break;
+                case 1:
+                    contextType = ContextType.Image;
+                    text = messageElement.TryGetProperty("content", out var imgEl) ? imgEl.GetString() : null;
+                    break;
+                case 14:
+                    contextType = ContextType.Video;
+                    text = messageElement.TryGetProperty("content", out var videoEl) ? videoEl.GetString() : null;
+                    break;
+                case 5:
+                    contextType = ContextType.Emotion;
+                    text = messageElement.TryGetProperty("info", out var emotionEl) ? emotionEl.ToString() : null;
+                    break;
+                case 64:
+                    contextType = ContextType.GoodsSpec;
+                    text = messageElement.TryGetProperty("info", out var specEl) ? specEl.ToString() : null;
+                    break;
+                case 24:
+                    contextType = ContextType.Transfer;
+                    text = messageElement.TryGetProperty("info", out var transferEl) ? transferEl.ToString() : null;
+                    break;
+                case 1002:
+                    contextType = ContextType.Withdraw;
+                    text = messageElement.TryGetProperty("info", out var withdrawEl) ? withdrawEl.ToString() : null;
+                    break;
+                default:
+                    contextType = ContextType.SystemStatus;
+                    text = $"不支持的消息类型: {type}";
+                    break;
+            }
+
+            message = new PddUserMessage(shopId, fromUid, nickname, contextType, text, root.Clone(), timestamp);
+            return true;
+        }
+    }
+}

--- a/dotnet/CustomerAgent.ConsoleApp/Services/PddMessageSender.cs
+++ b/dotnet/CustomerAgent.ConsoleApp/Services/PddMessageSender.cs
@@ -1,0 +1,62 @@
+using System.Text.Json;
+using CustomerAgent.ConsoleApp.Configuration;
+using CustomerAgent.ConsoleApp.Domain.Entities;
+using CustomerAgent.ConsoleApp.Infrastructure.Http;
+
+namespace CustomerAgent.ConsoleApp.Services;
+
+public class PddMessageSender
+{
+    private readonly AppSettings _settings;
+
+    public PddMessageSender(AppSettings settings)
+    {
+        _settings = settings;
+    }
+
+    public async Task SendTextAsync(Account account, string recipientUid, string content, CancellationToken cancellationToken)
+    {
+        using var client = new PddRequestClient(_settings);
+        client.UpdateCookies(account.Cookies);
+
+        var payload = new
+        {
+            data = new
+            {
+                cmd = "send_message",
+                request_id = GenerateRequestId(),
+                message = new
+                {
+                    to = new { role = "user", uid = recipientUid },
+                    from = new { role = "mall_cs" },
+                    content,
+                    msg_id = (string?)null,
+                    type = 0,
+                    is_aut = 0,
+                    manual_reply = 1
+                }
+            },
+            client = "WEB"
+        };
+
+        using var document = await client.PostJsonAsync("https://mms.pinduoduo.com/plateau/chat/send_message", payload, cancellationToken)
+            ?? throw new InvalidOperationException("发送消息失败: 空响应");
+
+        var root = document.RootElement;
+        if (!root.TryGetProperty("success", out var successEl) || successEl.ValueKind != JsonValueKind.True)
+        {
+            throw new InvalidOperationException($"发送消息失败: {root.ToString()}");
+        }
+
+        if (root.TryGetProperty("result", out var resultEl) && resultEl.TryGetProperty("error_code", out var codeEl) && codeEl.ValueKind == JsonValueKind.Number && codeEl.GetInt32() == 10002)
+        {
+            var error = resultEl.TryGetProperty("error", out var errorEl) ? errorEl.GetString() : "未知错误";
+            throw new InvalidOperationException($"发送消息失败: {error}");
+        }
+    }
+
+    private static string GenerateRequestId()
+    {
+        return Guid.NewGuid().ToString("N");
+    }
+}

--- a/dotnet/CustomerAgent.ConsoleApp/appsettings.json
+++ b/dotnet/CustomerAgent.ConsoleApp/appsettings.json
@@ -1,0 +1,14 @@
+{
+  "Pdd": {
+    "BusinessHours": {
+      "Start": "09:00",
+      "End": "23:00"
+    },
+    "DefaultHeaders": {
+      "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/137.0.0.0 Safari/537.36",
+      "Content-Type": "application/json",
+      "accept-language": "zh-CN,zh;q=0.9,en;q=0.8",
+      "priority": "u=1, i"
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- add a .NET 8 console application that recreates the Pinduoduo workflow using in-memory storage and JSON configuration
- implement HTTP clients for user/shop discovery, token retrieval, and message sending with cookie-based authentication
- add a WebSocket listener, message parser, and console dispatcher to support manual text replies

## Testing
- not run (dotnet CLI unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_68d7a2d2fa108330be745326f2670143